### PR TITLE
Check for external modules in container types

### DIFF
--- a/generate/gogen/types.go
+++ b/generate/gogen/types.go
@@ -27,3 +27,19 @@ var primTypeName = map[parser.PTypeID]string{
 	parser.UStringTypeID: "Ustring",
 	parser.BufferTypeID:  "Buffer",
 }
+
+// returns the external namespaces for the given type resolving recusively for
+// map values and vector inner types.
+func extNamespace(typ parser.Type) string {
+	switch t := typ.(type) {
+	case *parser.ClassType:
+		return t.Namespace
+	case *parser.VectorType:
+		return extNamespace(t.Type)
+	// TODO(bbennett): Since we always use pointers for class references we
+	// don't really support external classes used as keys. Do we need this?
+	case *parser.MapType:
+		return extNamespace(t.ValType)
+	}
+	return ""
+}


### PR DESCRIPTION
When looking for external modules to import into the file we were
only looking at *parser.ClassTypes and not looking to see if there
is a vector or map with an included type.

This adds a recursive lookup for vector item items, and map value types.
We are currently ignoring map key types as we only allow pointers to
classes and so key values would be pretty worthless.

Since jute will only really be used by zookeeper i think this is a fine
trade off as it doesn't use maps at all.