### PR TITLE
Had nil for vectors and buffers

### DIFF
--- a/generate/gogen/generator.go
+++ b/generate/gogen/generator.go
@@ -310,7 +310,7 @@ func (g *generator) serializeMethod(juteType parser.Type, fieldName string) (str
 			return "", err
 		}
 
-		fmt.Fprintf(w, "if err := enc.WriteVectorStart(len(%s)); err != nil {\n", fieldName)
+		fmt.Fprintf(w, "if err := enc.WriteVectorStart(len(%s), %s == nil); err != nil {\n", fieldName, fieldName)
 		fmt.Fprintf(w, "\treturn err\n")
 		fmt.Fprintf(w, "}\n")
 		fmt.Fprintf(w, "for _, v := range %s {\n", fieldName)
@@ -376,9 +376,13 @@ func (g *generator) deserializeMethod(juteType parser.Type, fieldName string, id
 		fmt.Fprintf(w, "if err != nil {\n")
 		fmt.Fprintf(w, "\treturn err\n")
 		fmt.Fprintf(w, "}\n")
-		fmt.Fprintf(w, "\t%s = make(%s, size)\n", fieldName, itemType)
-		fmt.Fprintf(w, "\tfor i := 0; i < size; i++ {\n")
+		fmt.Fprintf(w, "\tif size < 0 {\n")
+		fmt.Fprintf(w, "\t\t%s = nil\n", fieldName)
+		fmt.Fprintf(w, "\t} else {\n")
+		fmt.Fprintf(w, "\t\t%s = make(%s, size)\n", fieldName, itemType)
+		fmt.Fprintf(w, "\t\tfor i := 0; i < size; i++ {\n")
 		fmt.Fprint(w, itemMethod)
+		fmt.Fprintf(w, "\t}\n")
 		fmt.Fprintf(w, "}\n")
 		fmt.Fprintf(w, "if err = dec.ReadVectorEnd(); err != nil {\n")
 		fmt.Fprintf(w, "\treturn err\n")

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,1 @@
+github.com/go-zookeeper/zk v1.0.1 h1:LmXNmSnkNsNKai+aDu6sHRr8ZJzIrHJo8z8Z4sm8cT8=

--- a/lib/go/jute/binary_decoder.go
+++ b/lib/go/jute/binary_decoder.go
@@ -102,6 +102,10 @@ func (d *BinaryDecoder) ReadBuffer() ([]byte, error) {
 		return nil, err
 	}
 
+	if size < 0 {
+		return nil, nil
+	}
+
 	buf := make([]byte, int(size))
 	_, err = io.ReadFull(d.r, buf)
 	return buf, err

--- a/lib/go/jute/binary_encoder.go
+++ b/lib/go/jute/binary_encoder.go
@@ -102,6 +102,9 @@ func (s *BinaryEncoder) WriteUstring(v string) error {
 // WriteBuffer will write any byte slice by first writing it's length as 4
 // bytes followed by the bytes in the slice.
 func (s *BinaryEncoder) WriteBuffer(v []byte) error {
+	if v == nil {
+		return s.WriteInt(-1)
+	}
 	if err := s.WriteInt(int32(len(v))); err != nil {
 		return err
 	}
@@ -111,7 +114,10 @@ func (s *BinaryEncoder) WriteBuffer(v []byte) error {
 
 // WriteVectorStart will write out the number of items in the vector as 4
 // bytes.  After calling WriteVectorStart the caller should write out each item.
-func (s *BinaryEncoder) WriteVectorStart(l int) error {
+func (s *BinaryEncoder) WriteVectorStart(l int, isNil bool) error {
+	if isNil {
+		return s.WriteInt(-1)
+	}
 	return s.WriteInt(int32(l))
 } // WriteString will write a utf8 encoded string by first writing it's length as
 

--- a/lib/go/jute/binary_encoder_test.go
+++ b/lib/go/jute/binary_encoder_test.go
@@ -91,7 +91,7 @@ func TestBinaryEncoderVector(t *testing.T) {
 	if err := enc.WriteStart(); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if err := enc.WriteVectorStart(len(slice)); err != nil {
+	if err := enc.WriteVectorStart(len(slice), false); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 

--- a/lib/go/jute/interface.go
+++ b/lib/go/jute/interface.go
@@ -26,7 +26,7 @@ type Encoder interface {
 	WriteUstring(string) error
 	WriteBuffer([]byte) error
 
-	WriteVectorStart(len int) error
+	WriteVectorStart(len int, isNil bool) error
 	WriteVectorEnd() error
 
 	WriteMapStart(len int) error

--- a/testdata/fixtures/test/com/github/gozookeeper/jute/test/container.go
+++ b/testdata/fixtures/test/com/github/gozookeeper/jute/test/container.go
@@ -24,11 +24,15 @@ func (r *Container) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.V = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.V[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.V = nil
+	} else {
+		r.V = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.V[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -68,7 +72,7 @@ func (r *Container) Write(enc jute.Encoder) error {
 	if err := enc.WriteStart(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.V)); err != nil {
+	if err := enc.WriteVectorStart(len(r.V), r.V == nil); err != nil {
 		return err
 	}
 	for _, v := range r.V {

--- a/testdata/fixtures/zookeeper/proto/createrequest.go
+++ b/testdata/fixtures/zookeeper/proto/createrequest.go
@@ -34,10 +34,14 @@ func (r *CreateRequest) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Acl = make([]*data.ACL, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Acl[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Acl = nil
+	} else {
+		r.Acl = make([]*data.ACL, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Acl[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -63,7 +67,7 @@ func (r *CreateRequest) Write(enc jute.Encoder) error {
 	if err := enc.WriteBuffer(r.Data); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Acl)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Acl), r.Acl == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Acl {

--- a/testdata/fixtures/zookeeper/proto/createttlrequest.go
+++ b/testdata/fixtures/zookeeper/proto/createttlrequest.go
@@ -35,10 +35,14 @@ func (r *CreateTTLRequest) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Acl = make([]*data.ACL, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Acl[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Acl = nil
+	} else {
+		r.Acl = make([]*data.ACL, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Acl[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -68,7 +72,7 @@ func (r *CreateTTLRequest) Write(enc jute.Encoder) error {
 	if err := enc.WriteBuffer(r.Data); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Acl)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Acl), r.Acl == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Acl {

--- a/testdata/fixtures/zookeeper/proto/getaclresponse.go
+++ b/testdata/fixtures/zookeeper/proto/getaclresponse.go
@@ -24,10 +24,14 @@ func (r *GetACLResponse) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Acl = make([]*data.ACL, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Acl[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Acl = nil
+	} else {
+		r.Acl = make([]*data.ACL, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Acl[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -46,7 +50,7 @@ func (r *GetACLResponse) Write(enc jute.Encoder) error {
 	if err := enc.WriteStart(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Acl)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Acl), r.Acl == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Acl {

--- a/testdata/fixtures/zookeeper/proto/getchildren2response.go
+++ b/testdata/fixtures/zookeeper/proto/getchildren2response.go
@@ -24,11 +24,15 @@ func (r *GetChildren2Response) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Children = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.Children[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.Children = nil
+	} else {
+		r.Children = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.Children[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -47,7 +51,7 @@ func (r *GetChildren2Response) Write(enc jute.Encoder) error {
 	if err := enc.WriteStart(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Children)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Children), r.Children == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Children {

--- a/testdata/fixtures/zookeeper/proto/getchildrenresponse.go
+++ b/testdata/fixtures/zookeeper/proto/getchildrenresponse.go
@@ -22,11 +22,15 @@ func (r *GetChildrenResponse) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Children = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.Children[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.Children = nil
+	} else {
+		r.Children = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.Children[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -42,7 +46,7 @@ func (r *GetChildrenResponse) Write(enc jute.Encoder) error {
 	if err := enc.WriteStart(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Children)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Children), r.Children == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Children {

--- a/testdata/fixtures/zookeeper/proto/getephemeralsresponse.go
+++ b/testdata/fixtures/zookeeper/proto/getephemeralsresponse.go
@@ -22,11 +22,15 @@ func (r *GetEphemeralsResponse) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Ephemerals = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.Ephemerals[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.Ephemerals = nil
+	} else {
+		r.Ephemerals = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.Ephemerals[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -42,7 +46,7 @@ func (r *GetEphemeralsResponse) Write(enc jute.Encoder) error {
 	if err := enc.WriteStart(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Ephemerals)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Ephemerals), r.Ephemerals == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Ephemerals {

--- a/testdata/fixtures/zookeeper/proto/setaclrequest.go
+++ b/testdata/fixtures/zookeeper/proto/setaclrequest.go
@@ -29,10 +29,14 @@ func (r *SetACLRequest) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Acl = make([]*data.ACL, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Acl[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Acl = nil
+	} else {
+		r.Acl = make([]*data.ACL, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Acl[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -55,7 +59,7 @@ func (r *SetACLRequest) Write(enc jute.Encoder) error {
 	if err := enc.WriteUstring(r.Path); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Acl)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Acl), r.Acl == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Acl {

--- a/testdata/fixtures/zookeeper/proto/setwatches.go
+++ b/testdata/fixtures/zookeeper/proto/setwatches.go
@@ -29,11 +29,15 @@ func (r *SetWatches) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.DataWatches = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.DataWatches[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.DataWatches = nil
+	} else {
+		r.DataWatches = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.DataWatches[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -43,11 +47,15 @@ func (r *SetWatches) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.ExistWatches = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.ExistWatches[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.ExistWatches = nil
+	} else {
+		r.ExistWatches = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.ExistWatches[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -57,11 +65,15 @@ func (r *SetWatches) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.ChildWatches = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.ChildWatches[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.ChildWatches = nil
+	} else {
+		r.ChildWatches = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.ChildWatches[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -80,7 +92,7 @@ func (r *SetWatches) Write(enc jute.Encoder) error {
 	if err := enc.WriteLong(r.RelativeZxid); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.DataWatches)); err != nil {
+	if err := enc.WriteVectorStart(len(r.DataWatches), r.DataWatches == nil); err != nil {
 		return err
 	}
 	for _, v := range r.DataWatches {
@@ -91,7 +103,7 @@ func (r *SetWatches) Write(enc jute.Encoder) error {
 	if err := enc.WriteVectorEnd(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.ExistWatches)); err != nil {
+	if err := enc.WriteVectorStart(len(r.ExistWatches), r.ExistWatches == nil); err != nil {
 		return err
 	}
 	for _, v := range r.ExistWatches {
@@ -102,7 +114,7 @@ func (r *SetWatches) Write(enc jute.Encoder) error {
 	if err := enc.WriteVectorEnd(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.ChildWatches)); err != nil {
+	if err := enc.WriteVectorStart(len(r.ChildWatches), r.ChildWatches == nil); err != nil {
 		return err
 	}
 	for _, v := range r.ChildWatches {

--- a/testdata/fixtures/zookeeper/proto/setwatches2.go
+++ b/testdata/fixtures/zookeeper/proto/setwatches2.go
@@ -31,11 +31,15 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.DataWatches = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.DataWatches[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.DataWatches = nil
+	} else {
+		r.DataWatches = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.DataWatches[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -45,11 +49,15 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.ExistWatches = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.ExistWatches[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.ExistWatches = nil
+	} else {
+		r.ExistWatches = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.ExistWatches[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -59,11 +67,15 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.ChildWatches = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.ChildWatches[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.ChildWatches = nil
+	} else {
+		r.ChildWatches = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.ChildWatches[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -73,11 +85,15 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.PersistentWatches = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.PersistentWatches[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.PersistentWatches = nil
+	} else {
+		r.PersistentWatches = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.PersistentWatches[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -87,11 +103,15 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.PersistentRecursiveWatches = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.PersistentRecursiveWatches[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.PersistentRecursiveWatches = nil
+	} else {
+		r.PersistentRecursiveWatches = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.PersistentRecursiveWatches[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -110,7 +130,7 @@ func (r *SetWatches2) Write(enc jute.Encoder) error {
 	if err := enc.WriteLong(r.RelativeZxid); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.DataWatches)); err != nil {
+	if err := enc.WriteVectorStart(len(r.DataWatches), r.DataWatches == nil); err != nil {
 		return err
 	}
 	for _, v := range r.DataWatches {
@@ -121,7 +141,7 @@ func (r *SetWatches2) Write(enc jute.Encoder) error {
 	if err := enc.WriteVectorEnd(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.ExistWatches)); err != nil {
+	if err := enc.WriteVectorStart(len(r.ExistWatches), r.ExistWatches == nil); err != nil {
 		return err
 	}
 	for _, v := range r.ExistWatches {
@@ -132,7 +152,7 @@ func (r *SetWatches2) Write(enc jute.Encoder) error {
 	if err := enc.WriteVectorEnd(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.ChildWatches)); err != nil {
+	if err := enc.WriteVectorStart(len(r.ChildWatches), r.ChildWatches == nil); err != nil {
 		return err
 	}
 	for _, v := range r.ChildWatches {
@@ -143,7 +163,7 @@ func (r *SetWatches2) Write(enc jute.Encoder) error {
 	if err := enc.WriteVectorEnd(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.PersistentWatches)); err != nil {
+	if err := enc.WriteVectorStart(len(r.PersistentWatches), r.PersistentWatches == nil); err != nil {
 		return err
 	}
 	for _, v := range r.PersistentWatches {
@@ -154,7 +174,7 @@ func (r *SetWatches2) Write(enc jute.Encoder) error {
 	if err := enc.WriteVectorEnd(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.PersistentRecursiveWatches)); err != nil {
+	if err := enc.WriteVectorStart(len(r.PersistentRecursiveWatches), r.PersistentRecursiveWatches == nil); err != nil {
 		return err
 	}
 	for _, v := range r.PersistentRecursiveWatches {

--- a/testdata/fixtures/zookeeper/server/quorum/quorumpacket.go
+++ b/testdata/fixtures/zookeeper/server/quorum/quorumpacket.go
@@ -38,10 +38,14 @@ func (r *QuorumPacket) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Authinfo = make([]*data.Id, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Authinfo[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Authinfo = nil
+	} else {
+		r.Authinfo = make([]*data.Id, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Authinfo[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -66,7 +70,7 @@ func (r *QuorumPacket) Write(enc jute.Encoder) error {
 	if err := enc.WriteBuffer(r.Data); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Authinfo)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Authinfo), r.Authinfo == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Authinfo {

--- a/testdata/fixtures/zookeeper/txn/closesessiontxn.go
+++ b/testdata/fixtures/zookeeper/txn/closesessiontxn.go
@@ -22,11 +22,15 @@ func (r *CloseSessionTxn) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Paths2Delete = make([]string, size)
-	for i := 0; i < size; i++ {
-		r.Paths2Delete[i], err = dec.ReadUstring()
-		if err != nil {
-			return err
+	if size < 0 {
+		r.Paths2Delete = nil
+	} else {
+		r.Paths2Delete = make([]string, size)
+		for i := 0; i < size; i++ {
+			r.Paths2Delete[i], err = dec.ReadUstring()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -42,7 +46,7 @@ func (r *CloseSessionTxn) Write(enc jute.Encoder) error {
 	if err := enc.WriteStart(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Paths2Delete)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Paths2Delete), r.Paths2Delete == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Paths2Delete {

--- a/testdata/fixtures/zookeeper/txn/createcontainertxn.go
+++ b/testdata/fixtures/zookeeper/txn/createcontainertxn.go
@@ -34,10 +34,14 @@ func (r *CreateContainerTxn) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Acl = make([]*data.ACL, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Acl[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Acl = nil
+	} else {
+		r.Acl = make([]*data.ACL, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Acl[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -63,7 +67,7 @@ func (r *CreateContainerTxn) Write(enc jute.Encoder) error {
 	if err := enc.WriteBuffer(r.Data); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Acl)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Acl), r.Acl == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Acl {

--- a/testdata/fixtures/zookeeper/txn/createttltxn.go
+++ b/testdata/fixtures/zookeeper/txn/createttltxn.go
@@ -35,10 +35,14 @@ func (r *CreateTTLTxn) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Acl = make([]*data.ACL, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Acl[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Acl = nil
+	} else {
+		r.Acl = make([]*data.ACL, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Acl[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -68,7 +72,7 @@ func (r *CreateTTLTxn) Write(enc jute.Encoder) error {
 	if err := enc.WriteBuffer(r.Data); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Acl)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Acl), r.Acl == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Acl {

--- a/testdata/fixtures/zookeeper/txn/createtxn.go
+++ b/testdata/fixtures/zookeeper/txn/createtxn.go
@@ -35,10 +35,14 @@ func (r *CreateTxn) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Acl = make([]*data.ACL, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Acl[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Acl = nil
+	} else {
+		r.Acl = make([]*data.ACL, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Acl[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -68,7 +72,7 @@ func (r *CreateTxn) Write(enc jute.Encoder) error {
 	if err := enc.WriteBuffer(r.Data); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Acl)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Acl), r.Acl == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Acl {

--- a/testdata/fixtures/zookeeper/txn/createtxnv0.go
+++ b/testdata/fixtures/zookeeper/txn/createtxnv0.go
@@ -34,10 +34,14 @@ func (r *CreateTxnV0) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Acl = make([]*data.ACL, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Acl[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Acl = nil
+	} else {
+		r.Acl = make([]*data.ACL, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Acl[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -63,7 +67,7 @@ func (r *CreateTxnV0) Write(enc jute.Encoder) error {
 	if err := enc.WriteBuffer(r.Data); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Acl)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Acl), r.Acl == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Acl {

--- a/testdata/fixtures/zookeeper/txn/multitxn.go
+++ b/testdata/fixtures/zookeeper/txn/multitxn.go
@@ -23,10 +23,14 @@ func (r *MultiTxn) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Txns = make([]*txn.Txn, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Txns[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Txns = nil
+	} else {
+		r.Txns = make([]*txn.Txn, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Txns[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -42,7 +46,7 @@ func (r *MultiTxn) Write(enc jute.Encoder) error {
 	if err := enc.WriteStart(); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Txns)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Txns), r.Txns == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Txns {

--- a/testdata/fixtures/zookeeper/txn/setacltxn.go
+++ b/testdata/fixtures/zookeeper/txn/setacltxn.go
@@ -29,10 +29,14 @@ func (r *SetACLTxn) Read(dec jute.Decoder) (err error) {
 	if err != nil {
 		return err
 	}
-	r.Acl = make([]*data.ACL, size)
-	for i := 0; i < size; i++ {
-		if err = dec.ReadRecord(r.Acl[i]); err != nil {
-			return err
+	if size < 0 {
+		r.Acl = nil
+	} else {
+		r.Acl = make([]*data.ACL, size)
+		for i := 0; i < size; i++ {
+			if err = dec.ReadRecord(r.Acl[i]); err != nil {
+				return err
+			}
 		}
 	}
 	if err = dec.ReadVectorEnd(); err != nil {
@@ -55,7 +59,7 @@ func (r *SetACLTxn) Write(enc jute.Encoder) error {
 	if err := enc.WriteUstring(r.Path); err != nil {
 		return err
 	}
-	if err := enc.WriteVectorStart(len(r.Acl)); err != nil {
+	if err := enc.WriteVectorStart(len(r.Acl), r.Acl == nil); err != nil {
 		return err
 	}
 	for _, v := range r.Acl {


### PR DESCRIPTION
Buffer and vectors will return a -1 (0xffffffff) for a nil so we need to
support that.

Technically strings have a nil value as well but they aren't used in the
exisiting go zk client.