### PR TITLE
Make strings option by making them pointers

### DIFF
--- a/lib/go/jute/binary_decoder.go
+++ b/lib/go/jute/binary_decoder.go
@@ -88,10 +88,16 @@ func (d *BinaryDecoder) ReadDouble() (float64, error) {
 
 // ReadUstring will read a utf-8 encoded string first by reading the length
 // encoded as an int (4 bytes) and then reading that number of bytes.
-func (d *BinaryDecoder) ReadUstring() (string, error) {
+func (d *BinaryDecoder) ReadUstring() (*string, error) {
 	// TODO: optimize for small reads
 	p, err := d.ReadBuffer()
-	return string(p), err
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, nil
+	}
+	return StringPtr(string(p)), nil
 }
 
 // ReadBuffer will read a byte slice first by reading the length encoded as an

--- a/lib/go/jute/binary_decoder_test.go
+++ b/lib/go/jute/binary_decoder_test.go
@@ -127,8 +127,8 @@ func TestBinaryDecoderBase(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected err: %v", err)
 	}
-	if s1 != "hello" {
-		t.Errorf("ReadString: expected 'hello' got %q", s1)
+	if *s1 != "hello" {
+		t.Errorf("ReadString: expected 'hello' got %q", *s1)
 	}
 
 	buf1, err := dec.ReadBuffer()
@@ -230,7 +230,7 @@ func TestBinaryDecoderMap(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected err: %v", err)
 		}
-		m1[k] = v
+		m1[*k] = v
 	}
 
 	if err := dec.ReadMapEnd(); err != nil {

--- a/lib/go/jute/binary_encoder.go
+++ b/lib/go/jute/binary_encoder.go
@@ -91,11 +91,15 @@ func (s *BinaryEncoder) WriteDouble(i float64) error {
 
 // WriteUstring will write a utf8 encoded string by first writing it's length as
 // 4 bytes and then the byte of the string.
-func (s *BinaryEncoder) WriteUstring(v string) error {
-	if err := s.WriteInt(int32(len(v))); err != nil {
+func (s *BinaryEncoder) WriteUstring(v *string) error {
+	if v == nil {
+		return s.WriteInt(-1)
+	}
+
+	if err := s.WriteInt(int32(len(*v))); err != nil {
 		return err
 	}
-	_, err := s.w.WriteString(v)
+	_, err := s.w.WriteString(*v)
 	return err
 }
 

--- a/lib/go/jute/binary_encoder_test.go
+++ b/lib/go/jute/binary_encoder_test.go
@@ -47,7 +47,7 @@ func TestBinaryEncoderBase(t *testing.T) {
 	if err := enc.WriteDouble(3.14159265); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if err := enc.WriteUstring("hello"); err != nil {
+	if err := enc.WriteUstring(StringPtr("hello")); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	if err := enc.WriteBuffer([]byte{0x01, 0x02, 0x03, 0x04}); err != nil {
@@ -146,7 +146,7 @@ func TestBinaryEncoderMap(t *testing.T) {
 	}
 
 	for _, k := range keys(m1) {
-		if err := enc.WriteUstring(k); err != nil {
+		if err := enc.WriteUstring(&k); err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
 		if err := enc.WriteInt(m1[k]); err != nil {

--- a/lib/go/jute/interface.go
+++ b/lib/go/jute/interface.go
@@ -23,7 +23,7 @@ type Encoder interface {
 	WriteLong(int64) error
 	WriteFloat(float32) error
 	WriteDouble(float64) error
-	WriteUstring(string) error
+	WriteUstring(*string) error
 	WriteBuffer([]byte) error
 
 	WriteVectorStart(len int, isNil bool) error
@@ -46,7 +46,7 @@ type Decoder interface {
 	ReadLong() (int64, error)
 	ReadFloat() (float32, error)
 	ReadDouble() (float64, error)
-	ReadUstring() (string, error)
+	ReadUstring() (*string, error)
 	ReadBuffer() ([]byte, error)
 
 	ReadVectorStart() (int, error)

--- a/lib/go/jute/types.go
+++ b/lib/go/jute/types.go
@@ -1,0 +1,10 @@
+package jute
+
+import "errors"
+
+var ErrNilKey = errors.New("got nil value for map key")
+
+// Returns a pointer to a string
+func StringPtr(s string) *string {
+	return &s
+}

--- a/testdata/fixtures/test/com/github/gozookeeper/jute/test/basic.go
+++ b/testdata/fixtures/test/com/github/gozookeeper/jute/test/basic.go
@@ -16,7 +16,7 @@ type Basic struct {
 	L   int64   // l
 	F   float32 // f
 	D   float64 // d
-	S   string  // s
+	S   *string // s
 	Buf []byte  // buf
 }
 

--- a/testdata/fixtures/test/com/github/gozookeeper/jute/test/container.go
+++ b/testdata/fixtures/test/com/github/gozookeeper/jute/test/container.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Container struct {
-	V []string        // v
+	V []*string       // v
 	M map[int32]int32 // m
 	B *Basic          // b
 }
@@ -27,7 +27,7 @@ func (r *Container) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.V = nil
 	} else {
-		r.V = make([]string, size)
+		r.V = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.V[i], err = dec.ReadUstring()
 			if err != nil {

--- a/testdata/fixtures/test/com/github/gozookeeper/jute/test/nestedcontainer.go
+++ b/testdata/fixtures/test/com/github/gozookeeper/jute/test/nestedcontainer.go
@@ -38,18 +38,21 @@ func (r *NestedContainer) Read(dec jute.Decoder) (err error) {
 			return err
 		}
 		v0 = make(map[string]int32)
-		var k1 string
+		var k1 *string
 		var v1 int32
 		for i := 0; i < size; i++ {
 			k1, err = dec.ReadUstring()
 			if err != nil {
 				return err
 			}
+			if k1 == nil {
+				return jute.ErrNilKey
+			}
 			v1, err = dec.ReadInt()
 			if err != nil {
 				return err
 			}
-			v0[k1] = v1
+			v0[*k1] = v1
 		}
 		if err = dec.ReadMapEnd(); err != nil {
 			return err
@@ -64,12 +67,15 @@ func (r *NestedContainer) Read(dec jute.Decoder) (err error) {
 		return err
 	}
 	r.M2 = make(map[string][]float64)
-	var k1 string
+	var k1 *string
 	var v1 []float64
 	for i := 0; i < size; i++ {
 		k1, err = dec.ReadUstring()
 		if err != nil {
 			return err
+		}
+		if k1 == nil {
+			return jute.ErrNilKey
 		}
 		size, err = dec.ReadVectorStart()
 		if err != nil {
@@ -89,7 +95,7 @@ func (r *NestedContainer) Read(dec jute.Decoder) (err error) {
 		if err = dec.ReadVectorEnd(); err != nil {
 			return err
 		}
-		r.M2[k1] = v1
+		r.M2[*k1] = v1
 	}
 	if err = dec.ReadMapEnd(); err != nil {
 		return err

--- a/testdata/fixtures/zookeeper/data/id.go
+++ b/testdata/fixtures/zookeeper/data/id.go
@@ -10,8 +10,8 @@ import (
 )
 
 type Id struct {
-	Scheme string // scheme
-	Id     string // id
+	Scheme *string // scheme
+	Id     *string // id
 }
 
 func (r *Id) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/addwatchrequest.go
+++ b/testdata/fixtures/zookeeper/proto/addwatchrequest.go
@@ -10,8 +10,8 @@ import (
 )
 
 type AddWatchRequest struct {
-	Path string // path
-	Mode int32  // mode
+	Path *string // path
+	Mode int32   // mode
 }
 
 func (r *AddWatchRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/authpacket.go
+++ b/testdata/fixtures/zookeeper/proto/authpacket.go
@@ -10,9 +10,9 @@ import (
 )
 
 type AuthPacket struct {
-	Type   int32  // type
-	Scheme string // scheme
-	Auth   []byte // auth
+	Type   int32   // type
+	Scheme *string // scheme
+	Auth   []byte  // auth
 }
 
 func (r *AuthPacket) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/checkversionrequest.go
+++ b/testdata/fixtures/zookeeper/proto/checkversionrequest.go
@@ -10,8 +10,8 @@ import (
 )
 
 type CheckVersionRequest struct {
-	Path    string // path
-	Version int32  // version
+	Path    *string // path
+	Version int32   // version
 }
 
 func (r *CheckVersionRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/checkwatchesrequest.go
+++ b/testdata/fixtures/zookeeper/proto/checkwatchesrequest.go
@@ -10,8 +10,8 @@ import (
 )
 
 type CheckWatchesRequest struct {
-	Path string // path
-	Type int32  // type
+	Path *string // path
+	Type int32   // type
 }
 
 func (r *CheckWatchesRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/create2response.go
+++ b/testdata/fixtures/zookeeper/proto/create2response.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Create2Response struct {
-	Path string     // path
+	Path *string    // path
 	Stat *data.Stat // stat
 }
 

--- a/testdata/fixtures/zookeeper/proto/createrequest.go
+++ b/testdata/fixtures/zookeeper/proto/createrequest.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateRequest struct {
-	Path  string      // path
+	Path  *string     // path
 	Data  []byte      // data
 	Acl   []*data.ACL // acl
 	Flags int32       // flags

--- a/testdata/fixtures/zookeeper/proto/createresponse.go
+++ b/testdata/fixtures/zookeeper/proto/createresponse.go
@@ -10,7 +10,7 @@ import (
 )
 
 type CreateResponse struct {
-	Path string // path
+	Path *string // path
 }
 
 func (r *CreateResponse) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/createttlrequest.go
+++ b/testdata/fixtures/zookeeper/proto/createttlrequest.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateTTLRequest struct {
-	Path  string      // path
+	Path  *string     // path
 	Data  []byte      // data
 	Acl   []*data.ACL // acl
 	Flags int32       // flags

--- a/testdata/fixtures/zookeeper/proto/deleterequest.go
+++ b/testdata/fixtures/zookeeper/proto/deleterequest.go
@@ -10,8 +10,8 @@ import (
 )
 
 type DeleteRequest struct {
-	Path    string // path
-	Version int32  // version
+	Path    *string // path
+	Version int32   // version
 }
 
 func (r *DeleteRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/existsrequest.go
+++ b/testdata/fixtures/zookeeper/proto/existsrequest.go
@@ -10,8 +10,8 @@ import (
 )
 
 type ExistsRequest struct {
-	Path  string // path
-	Watch bool   // watch
+	Path  *string // path
+	Watch bool    // watch
 }
 
 func (r *ExistsRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/getaclrequest.go
+++ b/testdata/fixtures/zookeeper/proto/getaclrequest.go
@@ -10,7 +10,7 @@ import (
 )
 
 type GetACLRequest struct {
-	Path string // path
+	Path *string // path
 }
 
 func (r *GetACLRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/getallchildrennumberrequest.go
+++ b/testdata/fixtures/zookeeper/proto/getallchildrennumberrequest.go
@@ -10,7 +10,7 @@ import (
 )
 
 type GetAllChildrenNumberRequest struct {
-	Path string // path
+	Path *string // path
 }
 
 func (r *GetAllChildrenNumberRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/getchildren2request.go
+++ b/testdata/fixtures/zookeeper/proto/getchildren2request.go
@@ -10,8 +10,8 @@ import (
 )
 
 type GetChildren2Request struct {
-	Path  string // path
-	Watch bool   // watch
+	Path  *string // path
+	Watch bool    // watch
 }
 
 func (r *GetChildren2Request) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/getchildren2response.go
+++ b/testdata/fixtures/zookeeper/proto/getchildren2response.go
@@ -11,7 +11,7 @@ import (
 )
 
 type GetChildren2Response struct {
-	Children []string   // children
+	Children []*string  // children
 	Stat     *data.Stat // stat
 }
 
@@ -27,7 +27,7 @@ func (r *GetChildren2Response) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.Children = nil
 	} else {
-		r.Children = make([]string, size)
+		r.Children = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.Children[i], err = dec.ReadUstring()
 			if err != nil {

--- a/testdata/fixtures/zookeeper/proto/getchildrenrequest.go
+++ b/testdata/fixtures/zookeeper/proto/getchildrenrequest.go
@@ -10,8 +10,8 @@ import (
 )
 
 type GetChildrenRequest struct {
-	Path  string // path
-	Watch bool   // watch
+	Path  *string // path
+	Watch bool    // watch
 }
 
 func (r *GetChildrenRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/getchildrenresponse.go
+++ b/testdata/fixtures/zookeeper/proto/getchildrenresponse.go
@@ -10,7 +10,7 @@ import (
 )
 
 type GetChildrenResponse struct {
-	Children []string // children
+	Children []*string // children
 }
 
 func (r *GetChildrenResponse) Read(dec jute.Decoder) (err error) {
@@ -25,7 +25,7 @@ func (r *GetChildrenResponse) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.Children = nil
 	} else {
-		r.Children = make([]string, size)
+		r.Children = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.Children[i], err = dec.ReadUstring()
 			if err != nil {

--- a/testdata/fixtures/zookeeper/proto/getdatarequest.go
+++ b/testdata/fixtures/zookeeper/proto/getdatarequest.go
@@ -10,8 +10,8 @@ import (
 )
 
 type GetDataRequest struct {
-	Path  string // path
-	Watch bool   // watch
+	Path  *string // path
+	Watch bool    // watch
 }
 
 func (r *GetDataRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/getephemeralsrequest.go
+++ b/testdata/fixtures/zookeeper/proto/getephemeralsrequest.go
@@ -10,7 +10,7 @@ import (
 )
 
 type GetEphemeralsRequest struct {
-	PrefixPath string // prefixPath
+	PrefixPath *string // prefixPath
 }
 
 func (r *GetEphemeralsRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/getephemeralsresponse.go
+++ b/testdata/fixtures/zookeeper/proto/getephemeralsresponse.go
@@ -10,7 +10,7 @@ import (
 )
 
 type GetEphemeralsResponse struct {
-	Ephemerals []string // ephemerals
+	Ephemerals []*string // ephemerals
 }
 
 func (r *GetEphemeralsResponse) Read(dec jute.Decoder) (err error) {
@@ -25,7 +25,7 @@ func (r *GetEphemeralsResponse) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.Ephemerals = nil
 	} else {
-		r.Ephemerals = make([]string, size)
+		r.Ephemerals = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.Ephemerals[i], err = dec.ReadUstring()
 			if err != nil {

--- a/testdata/fixtures/zookeeper/proto/getmaxchildrenrequest.go
+++ b/testdata/fixtures/zookeeper/proto/getmaxchildrenrequest.go
@@ -10,7 +10,7 @@ import (
 )
 
 type GetMaxChildrenRequest struct {
-	Path string // path
+	Path *string // path
 }
 
 func (r *GetMaxChildrenRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/reconfigrequest.go
+++ b/testdata/fixtures/zookeeper/proto/reconfigrequest.go
@@ -10,10 +10,10 @@ import (
 )
 
 type ReconfigRequest struct {
-	JoiningServers string // joiningServers
-	LeavingServers string // leavingServers
-	NewMembers     string // newMembers
-	CurConfigId    int64  // curConfigId
+	JoiningServers *string // joiningServers
+	LeavingServers *string // leavingServers
+	NewMembers     *string // newMembers
+	CurConfigId    int64   // curConfigId
 }
 
 func (r *ReconfigRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/removewatchesrequest.go
+++ b/testdata/fixtures/zookeeper/proto/removewatchesrequest.go
@@ -10,8 +10,8 @@ import (
 )
 
 type RemoveWatchesRequest struct {
-	Path string // path
-	Type int32  // type
+	Path *string // path
+	Type int32   // type
 }
 
 func (r *RemoveWatchesRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/setaclrequest.go
+++ b/testdata/fixtures/zookeeper/proto/setaclrequest.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SetACLRequest struct {
-	Path    string      // path
+	Path    *string     // path
 	Acl     []*data.ACL // acl
 	Version int32       // version
 }

--- a/testdata/fixtures/zookeeper/proto/setdatarequest.go
+++ b/testdata/fixtures/zookeeper/proto/setdatarequest.go
@@ -10,9 +10,9 @@ import (
 )
 
 type SetDataRequest struct {
-	Path    string // path
-	Data    []byte // data
-	Version int32  // version
+	Path    *string // path
+	Data    []byte  // data
+	Version int32   // version
 }
 
 func (r *SetDataRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/setmaxchildrenrequest.go
+++ b/testdata/fixtures/zookeeper/proto/setmaxchildrenrequest.go
@@ -10,8 +10,8 @@ import (
 )
 
 type SetMaxChildrenRequest struct {
-	Path string // path
-	Max  int32  // max
+	Path *string // path
+	Max  int32   // max
 }
 
 func (r *SetMaxChildrenRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/setwatches.go
+++ b/testdata/fixtures/zookeeper/proto/setwatches.go
@@ -10,10 +10,10 @@ import (
 )
 
 type SetWatches struct {
-	RelativeZxid int64    // relativeZxid
-	DataWatches  []string // dataWatches
-	ExistWatches []string // existWatches
-	ChildWatches []string // childWatches
+	RelativeZxid int64     // relativeZxid
+	DataWatches  []*string // dataWatches
+	ExistWatches []*string // existWatches
+	ChildWatches []*string // childWatches
 }
 
 func (r *SetWatches) Read(dec jute.Decoder) (err error) {
@@ -32,7 +32,7 @@ func (r *SetWatches) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.DataWatches = nil
 	} else {
-		r.DataWatches = make([]string, size)
+		r.DataWatches = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.DataWatches[i], err = dec.ReadUstring()
 			if err != nil {
@@ -50,7 +50,7 @@ func (r *SetWatches) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.ExistWatches = nil
 	} else {
-		r.ExistWatches = make([]string, size)
+		r.ExistWatches = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.ExistWatches[i], err = dec.ReadUstring()
 			if err != nil {
@@ -68,7 +68,7 @@ func (r *SetWatches) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.ChildWatches = nil
 	} else {
-		r.ChildWatches = make([]string, size)
+		r.ChildWatches = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.ChildWatches[i], err = dec.ReadUstring()
 			if err != nil {

--- a/testdata/fixtures/zookeeper/proto/setwatches2.go
+++ b/testdata/fixtures/zookeeper/proto/setwatches2.go
@@ -10,12 +10,12 @@ import (
 )
 
 type SetWatches2 struct {
-	RelativeZxid               int64    // relativeZxid
-	DataWatches                []string // dataWatches
-	ExistWatches               []string // existWatches
-	ChildWatches               []string // childWatches
-	PersistentWatches          []string // persistentWatches
-	PersistentRecursiveWatches []string // persistentRecursiveWatches
+	RelativeZxid               int64     // relativeZxid
+	DataWatches                []*string // dataWatches
+	ExistWatches               []*string // existWatches
+	ChildWatches               []*string // childWatches
+	PersistentWatches          []*string // persistentWatches
+	PersistentRecursiveWatches []*string // persistentRecursiveWatches
 }
 
 func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
@@ -34,7 +34,7 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.DataWatches = nil
 	} else {
-		r.DataWatches = make([]string, size)
+		r.DataWatches = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.DataWatches[i], err = dec.ReadUstring()
 			if err != nil {
@@ -52,7 +52,7 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.ExistWatches = nil
 	} else {
-		r.ExistWatches = make([]string, size)
+		r.ExistWatches = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.ExistWatches[i], err = dec.ReadUstring()
 			if err != nil {
@@ -70,7 +70,7 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.ChildWatches = nil
 	} else {
-		r.ChildWatches = make([]string, size)
+		r.ChildWatches = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.ChildWatches[i], err = dec.ReadUstring()
 			if err != nil {
@@ -88,7 +88,7 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.PersistentWatches = nil
 	} else {
-		r.PersistentWatches = make([]string, size)
+		r.PersistentWatches = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.PersistentWatches[i], err = dec.ReadUstring()
 			if err != nil {
@@ -106,7 +106,7 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.PersistentRecursiveWatches = nil
 	} else {
-		r.PersistentRecursiveWatches = make([]string, size)
+		r.PersistentRecursiveWatches = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.PersistentRecursiveWatches[i], err = dec.ReadUstring()
 			if err != nil {

--- a/testdata/fixtures/zookeeper/proto/syncrequest.go
+++ b/testdata/fixtures/zookeeper/proto/syncrequest.go
@@ -10,7 +10,7 @@ import (
 )
 
 type SyncRequest struct {
-	Path string // path
+	Path *string // path
 }
 
 func (r *SyncRequest) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/syncresponse.go
+++ b/testdata/fixtures/zookeeper/proto/syncresponse.go
@@ -10,7 +10,7 @@ import (
 )
 
 type SyncResponse struct {
-	Path string // path
+	Path *string // path
 }
 
 func (r *SyncResponse) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/proto/watcherevent.go
+++ b/testdata/fixtures/zookeeper/proto/watcherevent.go
@@ -10,9 +10,9 @@ import (
 )
 
 type WatcherEvent struct {
-	Type  int32  // type
-	State int32  // state
-	Path  string // path
+	Type  int32   // type
+	State int32   // state
+	Path  *string // path
 }
 
 func (r *WatcherEvent) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/txn/checkversiontxn.go
+++ b/testdata/fixtures/zookeeper/txn/checkversiontxn.go
@@ -10,8 +10,8 @@ import (
 )
 
 type CheckVersionTxn struct {
-	Path    string // path
-	Version int32  // version
+	Path    *string // path
+	Version int32   // version
 }
 
 func (r *CheckVersionTxn) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/txn/closesessiontxn.go
+++ b/testdata/fixtures/zookeeper/txn/closesessiontxn.go
@@ -10,7 +10,7 @@ import (
 )
 
 type CloseSessionTxn struct {
-	Paths2Delete []string // paths2Delete
+	Paths2Delete []*string // paths2Delete
 }
 
 func (r *CloseSessionTxn) Read(dec jute.Decoder) (err error) {
@@ -25,7 +25,7 @@ func (r *CloseSessionTxn) Read(dec jute.Decoder) (err error) {
 	if size < 0 {
 		r.Paths2Delete = nil
 	} else {
-		r.Paths2Delete = make([]string, size)
+		r.Paths2Delete = make([]*string, size)
 		for i := 0; i < size; i++ {
 			r.Paths2Delete[i], err = dec.ReadUstring()
 			if err != nil {

--- a/testdata/fixtures/zookeeper/txn/createcontainertxn.go
+++ b/testdata/fixtures/zookeeper/txn/createcontainertxn.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateContainerTxn struct {
-	Path           string      // path
+	Path           *string     // path
 	Data           []byte      // data
 	Acl            []*data.ACL // acl
 	ParentCVersion int32       // parentCVersion

--- a/testdata/fixtures/zookeeper/txn/createttltxn.go
+++ b/testdata/fixtures/zookeeper/txn/createttltxn.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateTTLTxn struct {
-	Path           string      // path
+	Path           *string     // path
 	Data           []byte      // data
 	Acl            []*data.ACL // acl
 	ParentCVersion int32       // parentCVersion

--- a/testdata/fixtures/zookeeper/txn/createtxn.go
+++ b/testdata/fixtures/zookeeper/txn/createtxn.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateTxn struct {
-	Path           string      // path
+	Path           *string     // path
 	Data           []byte      // data
 	Acl            []*data.ACL // acl
 	Ephemeral      bool        // ephemeral

--- a/testdata/fixtures/zookeeper/txn/createtxnv0.go
+++ b/testdata/fixtures/zookeeper/txn/createtxnv0.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateTxnV0 struct {
-	Path      string      // path
+	Path      *string     // path
 	Data      []byte      // data
 	Acl       []*data.ACL // acl
 	Ephemeral bool        // ephemeral

--- a/testdata/fixtures/zookeeper/txn/deletetxn.go
+++ b/testdata/fixtures/zookeeper/txn/deletetxn.go
@@ -10,7 +10,7 @@ import (
 )
 
 type DeleteTxn struct {
-	Path string // path
+	Path *string // path
 }
 
 func (r *DeleteTxn) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/txn/setacltxn.go
+++ b/testdata/fixtures/zookeeper/txn/setacltxn.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SetACLTxn struct {
-	Path    string      // path
+	Path    *string     // path
 	Acl     []*data.ACL // acl
 	Version int32       // version
 }

--- a/testdata/fixtures/zookeeper/txn/setdatatxn.go
+++ b/testdata/fixtures/zookeeper/txn/setdatatxn.go
@@ -10,9 +10,9 @@ import (
 )
 
 type SetDataTxn struct {
-	Path    string // path
-	Data    []byte // data
-	Version int32  // version
+	Path    *string // path
+	Data    []byte  // data
+	Version int32   // version
 }
 
 func (r *SetDataTxn) Read(dec jute.Decoder) (err error) {

--- a/testdata/fixtures/zookeeper/txn/setmaxchildrentxn.go
+++ b/testdata/fixtures/zookeeper/txn/setmaxchildrentxn.go
@@ -10,8 +10,8 @@ import (
 )
 
 type SetMaxChildrenTxn struct {
-	Path string // path
-	Max  int32  // max
+	Path *string // path
+	Max  int32   // max
 }
 
 func (r *SetMaxChildrenTxn) Read(dec jute.Decoder) (err error) {


### PR DESCRIPTION
In Java strings can be nil and Jute uses this functionality for optional
strings.  To replicate this we can make all strings pointers.  It makes
the generate code a bit less friendly to use, but for the most part the
generate structs shouldn't be exposed to the end user so we can hide
this.