### PR TITLE
use string native type

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -2,4 +2,7 @@ coverage:
   status:
     patch:
       default:
-        target: 80%
+        target: 50%
+    project:
+      default:
+        threshold: 1%

--- a/generate/gogen/generator.go
+++ b/generate/gogen/generator.go
@@ -323,11 +323,7 @@ func (g *generator) serializeMethod(typ *goType, fieldName string) (string, erro
 	w := &strings.Builder{}
 	switch {
 	case typ.isPrimative():
-		var ref string
-		if !typ.isPtr && typ.typeID == typeString {
-			ref = "&"
-		}
-		fmt.Fprintf(w, "if err := enc.Write%s(%s%s); err != nil {\n", typ.methodSuffix(), ref, fieldName)
+		fmt.Fprintf(w, "if err := enc.Write%s(%s); err != nil {\n", typ.methodSuffix(), fieldName)
 		fmt.Fprintf(w, "\treturn err\n")
 		fmt.Fprintf(w, "}\n")
 	case typ.typeID == typeSlice:
@@ -384,23 +380,10 @@ func (g *generator) deserializeMethod(typ *goType, fieldName string, idx int) (s
 	w := &strings.Builder{}
 	switch {
 	case typ.isPrimative():
-		// for strings we may need to dereference a pointer
-		if !typ.isPtr && typ.typeID == typeString {
-			fmt.Fprintf(w, "s%d, err := dec.ReadString()\n", idx)
-			fmt.Fprintf(w, "if err != nil {\n")
-			fmt.Fprintf(w, "\treturn err\n")
-			fmt.Fprintf(w, "}\n")
-			fmt.Fprintf(w, "if s%d == nil {\n", idx)
-			fmt.Fprintf(w, "\t%s = \"\"\n", fieldName)
-			fmt.Fprintf(w, "} else {\n")
-			fmt.Fprintf(w, "\t%s = *s%d\n", fieldName, idx)
-			fmt.Fprintf(w, "}\n")
-		} else {
-			fmt.Fprintf(w, "%s, err = dec.Read%s()\n", fieldName, typ.methodSuffix())
-			fmt.Fprintf(w, "if err != nil {\n")
-			fmt.Fprintf(w, "\treturn err\n")
-			fmt.Fprintf(w, "}\n")
-		}
+		fmt.Fprintf(w, "%s, err = dec.Read%s()\n", fieldName, typ.methodSuffix())
+		fmt.Fprintf(w, "if err != nil {\n")
+		fmt.Fprintf(w, "\treturn err\n")
+		fmt.Fprintf(w, "}\n")
 	case typ.typeID == typeSlice:
 		itemMethod, err := g.deserializeMethod(typ.inner1, fmt.Sprintf("%s[i]", fieldName), idx+1)
 		if err != nil {

--- a/generate/gogen/types.go
+++ b/generate/gogen/types.go
@@ -122,27 +122,24 @@ func (t *goType) isNillable() bool {
 	}
 }
 
-var primTypeMap = map[parser.PTypeID]struct {
-	typeID typeID
-	ptr    bool
-}{
-	parser.BooleanTypeID: {typeBool, false},
-	parser.ByteTypeID:    {typeByte, false},
-	parser.IntTypeID:     {typeInt32, false},
-	parser.LongTypeID:    {typeInt64, false},
-	parser.FloatTypeID:   {typeFloat32, false},
-	parser.DoubleTypeID:  {typeFloat64, false},
-	parser.UStringTypeID: {typeString, true},
-	parser.BufferTypeID:  {typeByteSlice, false},
+var primTypeMap = map[parser.PTypeID]typeID {
+	parser.BooleanTypeID: typeBool,
+	parser.ByteTypeID:    typeByte,
+	parser.IntTypeID:     typeInt32,
+	parser.LongTypeID:    typeInt64,
+	parser.FloatTypeID:   typeFloat32,
+	parser.DoubleTypeID:  typeFloat64,
+	parser.UStringTypeID: typeString,
+	parser.BufferTypeID:  typeByteSlice,
 }
 
 func (g *generator) convertType(juteType parser.Type) (*goType, error) {
 	switch t := juteType.(type) {
 	case *parser.PType:
-		if spec, ok := primTypeMap[t.TypeID]; ok {
+		if typeID, ok := primTypeMap[t.TypeID]; ok {
 			return &goType{
-				typeID: spec.typeID,
-				isPtr:  spec.ptr,
+				typeID: typeID,
+				isPtr:  false,
 			}, nil
 		}
 		return nil, fmt.Errorf("unknown primative type %v", t.TypeID)

--- a/lib/go/jute/binary_decoder.go
+++ b/lib/go/jute/binary_decoder.go
@@ -88,16 +88,16 @@ func (d *BinaryDecoder) ReadDouble() (float64, error) {
 
 // ReadString will read a utf-8 encoded string first by reading the length
 // encoded as an int (4 bytes) and then reading that number of bytes.
-func (d *BinaryDecoder) ReadString() (*string, error) {
+func (d *BinaryDecoder) ReadString() (string, error) {
 	// TODO: optimize for small reads
 	p, err := d.ReadBuffer()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	if p == nil {
-		return nil, err
+		return "", err
 	}
-	return String(string(p)), nil
+	return string(p), nil
 }
 
 // ReadBuffer will read a byte slice first by reading the length encoded as an

--- a/lib/go/jute/binary_decoder_test.go
+++ b/lib/go/jute/binary_decoder_test.go
@@ -127,8 +127,8 @@ func TestBinaryDecoderBase(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected err: %v", err)
 	}
-	if *s1 != "hello" {
-		t.Errorf("ReadString: expected 'hello' got %q", *s1)
+	if s1 != "hello" {
+		t.Errorf("ReadString: expected 'hello' got %q", s1)
 	}
 
 	buf1, err := dec.ReadBuffer()
@@ -230,7 +230,7 @@ func TestBinaryDecoderMap(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected err: %v", err)
 		}
-		m1[*k] = v
+		m1[k] = v
 	}
 
 	if err := dec.ReadMapEnd(); err != nil {

--- a/lib/go/jute/binary_encoder.go
+++ b/lib/go/jute/binary_encoder.go
@@ -91,15 +91,15 @@ func (s *BinaryEncoder) WriteDouble(i float64) error {
 
 // WriteString will write a utf8 encoded string by first writing it's length as
 // 4 bytes and then the byte of the string.
-func (s *BinaryEncoder) WriteString(v *string) error {
-	if v == nil {
+func (s *BinaryEncoder) WriteString(v string) error {
+	if v == "" {
 		return s.WriteInt(-1)
 	}
 
-	if err := s.WriteInt(int32(len(*v))); err != nil {
+	if err := s.WriteInt(int32(len(v))); err != nil {
 		return err
 	}
-	_, err := s.w.WriteString(*v)
+	_, err := s.w.WriteString(v)
 	return err
 }
 

--- a/lib/go/jute/binary_encoder_test.go
+++ b/lib/go/jute/binary_encoder_test.go
@@ -47,7 +47,7 @@ func TestBinaryEncoderBase(t *testing.T) {
 	if err := enc.WriteDouble(3.14159265); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if err := enc.WriteString(String("hello")); err != nil {
+	if err := enc.WriteString("hello"); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	if err := enc.WriteBuffer([]byte{0x01, 0x02, 0x03, 0x04}); err != nil {
@@ -146,7 +146,7 @@ func TestBinaryEncoderMap(t *testing.T) {
 	}
 
 	for _, k := range keys(m1) {
-		if err := enc.WriteString(String(k)); err != nil {
+		if err := enc.WriteString(k); err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
 		if err := enc.WriteInt(m1[k]); err != nil {

--- a/lib/go/jute/interface.go
+++ b/lib/go/jute/interface.go
@@ -23,7 +23,7 @@ type Encoder interface {
 	WriteLong(int64) error
 	WriteFloat(float32) error
 	WriteDouble(float64) error
-	WriteString(*string) error
+	WriteString(string) error
 	WriteBuffer([]byte) error
 
 	WriteVectorStart(len int, isNil bool) error
@@ -46,7 +46,7 @@ type Decoder interface {
 	ReadLong() (int64, error)
 	ReadFloat() (float32, error)
 	ReadDouble() (float64, error)
-	ReadString() (*string, error)
+	ReadString() (string, error)
 	ReadBuffer() ([]byte, error)
 
 	ReadVectorStart() (int, error)

--- a/testdata/fixtures/test/com/github/gozookeeper/jute/test/basic.go
+++ b/testdata/fixtures/test/com/github/gozookeeper/jute/test/basic.go
@@ -16,7 +16,7 @@ type Basic struct {
 	L   int64   // l
 	F   float32 // f
 	D   float64 // d
-	S   *string // s
+	S   string  // s
 	Buf []byte  // buf
 }
 
@@ -63,8 +63,8 @@ func (r *Basic) GetD() float64 {
 }
 
 func (r *Basic) GetS() string {
-	if r != nil && r.S != nil {
-		return *r.S
+	if r != nil {
+		return r.S
 	}
 	return ""
 }

--- a/testdata/fixtures/test/com/github/gozookeeper/jute/test/container.go
+++ b/testdata/fixtures/test/com/github/gozookeeper/jute/test/container.go
@@ -58,14 +58,9 @@ func (r *Container) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.V = make([]string, size)
 		for i := 0; i < size; i++ {
-			s1, err := dec.ReadString()
+			r.V[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s1 == nil {
-				r.V[i] = ""
-			} else {
-				r.V[i] = *s1
 			}
 		}
 	}
@@ -80,23 +75,13 @@ func (r *Container) Read(dec jute.Decoder) (err error) {
 	var k1 string
 	var v1 string
 	for i := 0; i < size; i++ {
-		s2, err := dec.ReadString()
+		k1, err = dec.ReadString()
 		if err != nil {
 			return err
 		}
-		if s2 == nil {
-			k1 = ""
-		} else {
-			k1 = *s2
-		}
-		s2, err := dec.ReadString()
+		v1, err = dec.ReadString()
 		if err != nil {
 			return err
-		}
-		if s2 == nil {
-			v1 = ""
-		} else {
-			v1 = *s2
 		}
 		r.M1[k1] = v1
 	}
@@ -141,7 +126,7 @@ func (r *Container) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.V {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}
@@ -152,10 +137,10 @@ func (r *Container) Write(enc jute.Encoder) error {
 		return err
 	}
 	for k, v := range r.M1 {
-		if err := enc.WriteString(&k); err != nil {
+		if err := enc.WriteString(k); err != nil {
 			return err
 		}
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}

--- a/testdata/fixtures/test/com/github/gozookeeper/jute/test/nestedcontainer.go
+++ b/testdata/fixtures/test/com/github/gozookeeper/jute/test/nestedcontainer.go
@@ -69,14 +69,9 @@ func (r *NestedContainer) Read(dec jute.Decoder) (err error) {
 		var k1 string
 		var v1 int32
 		for i := 0; i < size; i++ {
-			s2, err := dec.ReadString()
+			k1, err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s2 == nil {
-				k1 = ""
-			} else {
-				k1 = *s2
 			}
 			v1, err = dec.ReadInt()
 			if err != nil {
@@ -100,14 +95,9 @@ func (r *NestedContainer) Read(dec jute.Decoder) (err error) {
 	var k1 string
 	var v1 []float64
 	for i := 0; i < size; i++ {
-		s2, err := dec.ReadString()
+		k1, err = dec.ReadString()
 		if err != nil {
 			return err
-		}
-		if s2 == nil {
-			k1 = ""
-		} else {
-			k1 = *s2
 		}
 		size, err = dec.ReadVectorStart()
 		if err != nil {
@@ -233,7 +223,7 @@ func (r *NestedContainer) Write(enc jute.Encoder) error {
 			return err
 		}
 		for k, v := range v {
-			if err := enc.WriteString(&k); err != nil {
+			if err := enc.WriteString(k); err != nil {
 				return err
 			}
 			if err := enc.WriteInt(v); err != nil {
@@ -251,7 +241,7 @@ func (r *NestedContainer) Write(enc jute.Encoder) error {
 		return err
 	}
 	for k, v := range r.M2 {
-		if err := enc.WriteString(&k); err != nil {
+		if err := enc.WriteString(k); err != nil {
 			return err
 		}
 		if err := enc.WriteVectorStart(len(v), v == nil); err != nil {

--- a/testdata/fixtures/zookeeper/data/id.go
+++ b/testdata/fixtures/zookeeper/data/id.go
@@ -10,20 +10,20 @@ import (
 )
 
 type Id struct {
-	Scheme *string // scheme
-	Id     *string // id
+	Scheme string // scheme
+	Id     string // id
 }
 
 func (r *Id) GetScheme() string {
-	if r != nil && r.Scheme != nil {
-		return *r.Scheme
+	if r != nil {
+		return r.Scheme
 	}
 	return ""
 }
 
 func (r *Id) GetId() string {
-	if r != nil && r.Id != nil {
-		return *r.Id
+	if r != nil {
+		return r.Id
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/addwatchrequest.go
+++ b/testdata/fixtures/zookeeper/proto/addwatchrequest.go
@@ -10,13 +10,13 @@ import (
 )
 
 type AddWatchRequest struct {
-	Path *string // path
-	Mode int32   // mode
+	Path string // path
+	Mode int32  // mode
 }
 
 func (r *AddWatchRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/authpacket.go
+++ b/testdata/fixtures/zookeeper/proto/authpacket.go
@@ -10,9 +10,9 @@ import (
 )
 
 type AuthPacket struct {
-	Type   int32   // type
-	Scheme *string // scheme
-	Auth   []byte  // auth
+	Type   int32  // type
+	Scheme string // scheme
+	Auth   []byte // auth
 }
 
 func (r *AuthPacket) GetType() int32 {
@@ -23,8 +23,8 @@ func (r *AuthPacket) GetType() int32 {
 }
 
 func (r *AuthPacket) GetScheme() string {
-	if r != nil && r.Scheme != nil {
-		return *r.Scheme
+	if r != nil {
+		return r.Scheme
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/checkversionrequest.go
+++ b/testdata/fixtures/zookeeper/proto/checkversionrequest.go
@@ -10,13 +10,13 @@ import (
 )
 
 type CheckVersionRequest struct {
-	Path    *string // path
-	Version int32   // version
+	Path    string // path
+	Version int32  // version
 }
 
 func (r *CheckVersionRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/checkwatchesrequest.go
+++ b/testdata/fixtures/zookeeper/proto/checkwatchesrequest.go
@@ -10,13 +10,13 @@ import (
 )
 
 type CheckWatchesRequest struct {
-	Path *string // path
-	Type int32   // type
+	Path string // path
+	Type int32  // type
 }
 
 func (r *CheckWatchesRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/create2response.go
+++ b/testdata/fixtures/zookeeper/proto/create2response.go
@@ -11,13 +11,13 @@ import (
 )
 
 type Create2Response struct {
-	Path *string    // path
+	Path string     // path
 	Stat *data.Stat // stat
 }
 
 func (r *Create2Response) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/createrequest.go
+++ b/testdata/fixtures/zookeeper/proto/createrequest.go
@@ -11,15 +11,15 @@ import (
 )
 
 type CreateRequest struct {
-	Path  *string     // path
+	Path  string      // path
 	Data  []byte      // data
 	Acl   []*data.ACL // acl
 	Flags int32       // flags
 }
 
 func (r *CreateRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/createresponse.go
+++ b/testdata/fixtures/zookeeper/proto/createresponse.go
@@ -10,12 +10,12 @@ import (
 )
 
 type CreateResponse struct {
-	Path *string // path
+	Path string // path
 }
 
 func (r *CreateResponse) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/createttlrequest.go
+++ b/testdata/fixtures/zookeeper/proto/createttlrequest.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateTTLRequest struct {
-	Path  *string     // path
+	Path  string      // path
 	Data  []byte      // data
 	Acl   []*data.ACL // acl
 	Flags int32       // flags
@@ -19,8 +19,8 @@ type CreateTTLRequest struct {
 }
 
 func (r *CreateTTLRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/deleterequest.go
+++ b/testdata/fixtures/zookeeper/proto/deleterequest.go
@@ -10,13 +10,13 @@ import (
 )
 
 type DeleteRequest struct {
-	Path    *string // path
-	Version int32   // version
+	Path    string // path
+	Version int32  // version
 }
 
 func (r *DeleteRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/existsrequest.go
+++ b/testdata/fixtures/zookeeper/proto/existsrequest.go
@@ -10,13 +10,13 @@ import (
 )
 
 type ExistsRequest struct {
-	Path  *string // path
-	Watch bool    // watch
+	Path  string // path
+	Watch bool   // watch
 }
 
 func (r *ExistsRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/getaclrequest.go
+++ b/testdata/fixtures/zookeeper/proto/getaclrequest.go
@@ -10,12 +10,12 @@ import (
 )
 
 type GetACLRequest struct {
-	Path *string // path
+	Path string // path
 }
 
 func (r *GetACLRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/getallchildrennumberrequest.go
+++ b/testdata/fixtures/zookeeper/proto/getallchildrennumberrequest.go
@@ -10,12 +10,12 @@ import (
 )
 
 type GetAllChildrenNumberRequest struct {
-	Path *string // path
+	Path string // path
 }
 
 func (r *GetAllChildrenNumberRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/getchildren2request.go
+++ b/testdata/fixtures/zookeeper/proto/getchildren2request.go
@@ -10,13 +10,13 @@ import (
 )
 
 type GetChildren2Request struct {
-	Path  *string // path
-	Watch bool    // watch
+	Path  string // path
+	Watch bool   // watch
 }
 
 func (r *GetChildren2Request) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/getchildren2response.go
+++ b/testdata/fixtures/zookeeper/proto/getchildren2response.go
@@ -43,14 +43,9 @@ func (r *GetChildren2Response) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.Children = make([]string, size)
 		for i := 0; i < size; i++ {
-			s1, err := dec.ReadString()
+			r.Children[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s1 == nil {
-				r.Children[i] = ""
-			} else {
-				r.Children[i] = *s1
 			}
 		}
 	}
@@ -74,7 +69,7 @@ func (r *GetChildren2Response) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.Children {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}

--- a/testdata/fixtures/zookeeper/proto/getchildrenrequest.go
+++ b/testdata/fixtures/zookeeper/proto/getchildrenrequest.go
@@ -10,13 +10,13 @@ import (
 )
 
 type GetChildrenRequest struct {
-	Path  *string // path
-	Watch bool    // watch
+	Path  string // path
+	Watch bool   // watch
 }
 
 func (r *GetChildrenRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/getchildrenresponse.go
+++ b/testdata/fixtures/zookeeper/proto/getchildrenresponse.go
@@ -34,14 +34,9 @@ func (r *GetChildrenResponse) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.Children = make([]string, size)
 		for i := 0; i < size; i++ {
-			s1, err := dec.ReadString()
+			r.Children[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s1 == nil {
-				r.Children[i] = ""
-			} else {
-				r.Children[i] = *s1
 			}
 		}
 	}
@@ -62,7 +57,7 @@ func (r *GetChildrenResponse) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.Children {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}

--- a/testdata/fixtures/zookeeper/proto/getdatarequest.go
+++ b/testdata/fixtures/zookeeper/proto/getdatarequest.go
@@ -10,13 +10,13 @@ import (
 )
 
 type GetDataRequest struct {
-	Path  *string // path
-	Watch bool    // watch
+	Path  string // path
+	Watch bool   // watch
 }
 
 func (r *GetDataRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/getephemeralsrequest.go
+++ b/testdata/fixtures/zookeeper/proto/getephemeralsrequest.go
@@ -10,12 +10,12 @@ import (
 )
 
 type GetEphemeralsRequest struct {
-	PrefixPath *string // prefixPath
+	PrefixPath string // prefixPath
 }
 
 func (r *GetEphemeralsRequest) GetPrefixPath() string {
-	if r != nil && r.PrefixPath != nil {
-		return *r.PrefixPath
+	if r != nil {
+		return r.PrefixPath
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/getephemeralsresponse.go
+++ b/testdata/fixtures/zookeeper/proto/getephemeralsresponse.go
@@ -34,14 +34,9 @@ func (r *GetEphemeralsResponse) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.Ephemerals = make([]string, size)
 		for i := 0; i < size; i++ {
-			s1, err := dec.ReadString()
+			r.Ephemerals[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s1 == nil {
-				r.Ephemerals[i] = ""
-			} else {
-				r.Ephemerals[i] = *s1
 			}
 		}
 	}
@@ -62,7 +57,7 @@ func (r *GetEphemeralsResponse) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.Ephemerals {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}

--- a/testdata/fixtures/zookeeper/proto/getmaxchildrenrequest.go
+++ b/testdata/fixtures/zookeeper/proto/getmaxchildrenrequest.go
@@ -10,12 +10,12 @@ import (
 )
 
 type GetMaxChildrenRequest struct {
-	Path *string // path
+	Path string // path
 }
 
 func (r *GetMaxChildrenRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/reconfigrequest.go
+++ b/testdata/fixtures/zookeeper/proto/reconfigrequest.go
@@ -10,29 +10,29 @@ import (
 )
 
 type ReconfigRequest struct {
-	JoiningServers *string // joiningServers
-	LeavingServers *string // leavingServers
-	NewMembers     *string // newMembers
-	CurConfigId    int64   // curConfigId
+	JoiningServers string // joiningServers
+	LeavingServers string // leavingServers
+	NewMembers     string // newMembers
+	CurConfigId    int64  // curConfigId
 }
 
 func (r *ReconfigRequest) GetJoiningServers() string {
-	if r != nil && r.JoiningServers != nil {
-		return *r.JoiningServers
+	if r != nil {
+		return r.JoiningServers
 	}
 	return ""
 }
 
 func (r *ReconfigRequest) GetLeavingServers() string {
-	if r != nil && r.LeavingServers != nil {
-		return *r.LeavingServers
+	if r != nil {
+		return r.LeavingServers
 	}
 	return ""
 }
 
 func (r *ReconfigRequest) GetNewMembers() string {
-	if r != nil && r.NewMembers != nil {
-		return *r.NewMembers
+	if r != nil {
+		return r.NewMembers
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/removewatchesrequest.go
+++ b/testdata/fixtures/zookeeper/proto/removewatchesrequest.go
@@ -10,13 +10,13 @@ import (
 )
 
 type RemoveWatchesRequest struct {
-	Path *string // path
-	Type int32   // type
+	Path string // path
+	Type int32  // type
 }
 
 func (r *RemoveWatchesRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/setaclrequest.go
+++ b/testdata/fixtures/zookeeper/proto/setaclrequest.go
@@ -11,14 +11,14 @@ import (
 )
 
 type SetACLRequest struct {
-	Path    *string     // path
+	Path    string      // path
 	Acl     []*data.ACL // acl
 	Version int32       // version
 }
 
 func (r *SetACLRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/setdatarequest.go
+++ b/testdata/fixtures/zookeeper/proto/setdatarequest.go
@@ -10,14 +10,14 @@ import (
 )
 
 type SetDataRequest struct {
-	Path    *string // path
-	Data    []byte  // data
-	Version int32   // version
+	Path    string // path
+	Data    []byte // data
+	Version int32  // version
 }
 
 func (r *SetDataRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/setmaxchildrenrequest.go
+++ b/testdata/fixtures/zookeeper/proto/setmaxchildrenrequest.go
@@ -10,13 +10,13 @@ import (
 )
 
 type SetMaxChildrenRequest struct {
-	Path *string // path
-	Max  int32   // max
+	Path string // path
+	Max  int32  // max
 }
 
 func (r *SetMaxChildrenRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/setwatches.go
+++ b/testdata/fixtures/zookeeper/proto/setwatches.go
@@ -62,14 +62,9 @@ func (r *SetWatches) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.DataWatches = make([]string, size)
 		for i := 0; i < size; i++ {
-			s2, err := dec.ReadString()
+			r.DataWatches[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s2 == nil {
-				r.DataWatches[i] = ""
-			} else {
-				r.DataWatches[i] = *s2
 			}
 		}
 	}
@@ -85,14 +80,9 @@ func (r *SetWatches) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.ExistWatches = make([]string, size)
 		for i := 0; i < size; i++ {
-			s3, err := dec.ReadString()
+			r.ExistWatches[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s3 == nil {
-				r.ExistWatches[i] = ""
-			} else {
-				r.ExistWatches[i] = *s3
 			}
 		}
 	}
@@ -108,14 +98,9 @@ func (r *SetWatches) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.ChildWatches = make([]string, size)
 		for i := 0; i < size; i++ {
-			s4, err := dec.ReadString()
+			r.ChildWatches[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s4 == nil {
-				r.ChildWatches[i] = ""
-			} else {
-				r.ChildWatches[i] = *s4
 			}
 		}
 	}
@@ -139,7 +124,7 @@ func (r *SetWatches) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.DataWatches {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}
@@ -150,7 +135,7 @@ func (r *SetWatches) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.ExistWatches {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}
@@ -161,7 +146,7 @@ func (r *SetWatches) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.ChildWatches {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}

--- a/testdata/fixtures/zookeeper/proto/setwatches2.go
+++ b/testdata/fixtures/zookeeper/proto/setwatches2.go
@@ -78,14 +78,9 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.DataWatches = make([]string, size)
 		for i := 0; i < size; i++ {
-			s2, err := dec.ReadString()
+			r.DataWatches[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s2 == nil {
-				r.DataWatches[i] = ""
-			} else {
-				r.DataWatches[i] = *s2
 			}
 		}
 	}
@@ -101,14 +96,9 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.ExistWatches = make([]string, size)
 		for i := 0; i < size; i++ {
-			s3, err := dec.ReadString()
+			r.ExistWatches[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s3 == nil {
-				r.ExistWatches[i] = ""
-			} else {
-				r.ExistWatches[i] = *s3
 			}
 		}
 	}
@@ -124,14 +114,9 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.ChildWatches = make([]string, size)
 		for i := 0; i < size; i++ {
-			s4, err := dec.ReadString()
+			r.ChildWatches[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s4 == nil {
-				r.ChildWatches[i] = ""
-			} else {
-				r.ChildWatches[i] = *s4
 			}
 		}
 	}
@@ -147,14 +132,9 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.PersistentWatches = make([]string, size)
 		for i := 0; i < size; i++ {
-			s5, err := dec.ReadString()
+			r.PersistentWatches[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s5 == nil {
-				r.PersistentWatches[i] = ""
-			} else {
-				r.PersistentWatches[i] = *s5
 			}
 		}
 	}
@@ -170,14 +150,9 @@ func (r *SetWatches2) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.PersistentRecursiveWatches = make([]string, size)
 		for i := 0; i < size; i++ {
-			s6, err := dec.ReadString()
+			r.PersistentRecursiveWatches[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s6 == nil {
-				r.PersistentRecursiveWatches[i] = ""
-			} else {
-				r.PersistentRecursiveWatches[i] = *s6
 			}
 		}
 	}
@@ -201,7 +176,7 @@ func (r *SetWatches2) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.DataWatches {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}
@@ -212,7 +187,7 @@ func (r *SetWatches2) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.ExistWatches {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}
@@ -223,7 +198,7 @@ func (r *SetWatches2) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.ChildWatches {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}
@@ -234,7 +209,7 @@ func (r *SetWatches2) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.PersistentWatches {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}
@@ -245,7 +220,7 @@ func (r *SetWatches2) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.PersistentRecursiveWatches {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}

--- a/testdata/fixtures/zookeeper/proto/syncrequest.go
+++ b/testdata/fixtures/zookeeper/proto/syncrequest.go
@@ -10,12 +10,12 @@ import (
 )
 
 type SyncRequest struct {
-	Path *string // path
+	Path string // path
 }
 
 func (r *SyncRequest) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/syncresponse.go
+++ b/testdata/fixtures/zookeeper/proto/syncresponse.go
@@ -10,12 +10,12 @@ import (
 )
 
 type SyncResponse struct {
-	Path *string // path
+	Path string // path
 }
 
 func (r *SyncResponse) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/proto/watcherevent.go
+++ b/testdata/fixtures/zookeeper/proto/watcherevent.go
@@ -10,9 +10,9 @@ import (
 )
 
 type WatcherEvent struct {
-	Type  int32   // type
-	State int32   // state
-	Path  *string // path
+	Type  int32  // type
+	State int32  // state
+	Path  string // path
 }
 
 func (r *WatcherEvent) GetType() int32 {
@@ -30,8 +30,8 @@ func (r *WatcherEvent) GetState() int32 {
 }
 
 func (r *WatcherEvent) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/txn/checkversiontxn.go
+++ b/testdata/fixtures/zookeeper/txn/checkversiontxn.go
@@ -10,13 +10,13 @@ import (
 )
 
 type CheckVersionTxn struct {
-	Path    *string // path
-	Version int32   // version
+	Path    string // path
+	Version int32  // version
 }
 
 func (r *CheckVersionTxn) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/txn/closesessiontxn.go
+++ b/testdata/fixtures/zookeeper/txn/closesessiontxn.go
@@ -34,14 +34,9 @@ func (r *CloseSessionTxn) Read(dec jute.Decoder) (err error) {
 	} else {
 		r.Paths2Delete = make([]string, size)
 		for i := 0; i < size; i++ {
-			s1, err := dec.ReadString()
+			r.Paths2Delete[i], err = dec.ReadString()
 			if err != nil {
 				return err
-			}
-			if s1 == nil {
-				r.Paths2Delete[i] = ""
-			} else {
-				r.Paths2Delete[i] = *s1
 			}
 		}
 	}
@@ -62,7 +57,7 @@ func (r *CloseSessionTxn) Write(enc jute.Encoder) error {
 		return err
 	}
 	for _, v := range r.Paths2Delete {
-		if err := enc.WriteString(&v); err != nil {
+		if err := enc.WriteString(v); err != nil {
 			return err
 		}
 	}

--- a/testdata/fixtures/zookeeper/txn/createcontainertxn.go
+++ b/testdata/fixtures/zookeeper/txn/createcontainertxn.go
@@ -11,15 +11,15 @@ import (
 )
 
 type CreateContainerTxn struct {
-	Path           *string     // path
+	Path           string      // path
 	Data           []byte      // data
 	Acl            []*data.ACL // acl
 	ParentCVersion int32       // parentCVersion
 }
 
 func (r *CreateContainerTxn) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/txn/createttltxn.go
+++ b/testdata/fixtures/zookeeper/txn/createttltxn.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateTTLTxn struct {
-	Path           *string     // path
+	Path           string      // path
 	Data           []byte      // data
 	Acl            []*data.ACL // acl
 	ParentCVersion int32       // parentCVersion
@@ -19,8 +19,8 @@ type CreateTTLTxn struct {
 }
 
 func (r *CreateTTLTxn) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/txn/createtxn.go
+++ b/testdata/fixtures/zookeeper/txn/createtxn.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateTxn struct {
-	Path           *string     // path
+	Path           string      // path
 	Data           []byte      // data
 	Acl            []*data.ACL // acl
 	Ephemeral      bool        // ephemeral
@@ -19,8 +19,8 @@ type CreateTxn struct {
 }
 
 func (r *CreateTxn) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/txn/createtxnv0.go
+++ b/testdata/fixtures/zookeeper/txn/createtxnv0.go
@@ -11,15 +11,15 @@ import (
 )
 
 type CreateTxnV0 struct {
-	Path      *string     // path
+	Path      string      // path
 	Data      []byte      // data
 	Acl       []*data.ACL // acl
 	Ephemeral bool        // ephemeral
 }
 
 func (r *CreateTxnV0) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/txn/deletetxn.go
+++ b/testdata/fixtures/zookeeper/txn/deletetxn.go
@@ -10,12 +10,12 @@ import (
 )
 
 type DeleteTxn struct {
-	Path *string // path
+	Path string // path
 }
 
 func (r *DeleteTxn) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/txn/setacltxn.go
+++ b/testdata/fixtures/zookeeper/txn/setacltxn.go
@@ -11,14 +11,14 @@ import (
 )
 
 type SetACLTxn struct {
-	Path    *string     // path
+	Path    string      // path
 	Acl     []*data.ACL // acl
 	Version int32       // version
 }
 
 func (r *SetACLTxn) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/txn/setdatatxn.go
+++ b/testdata/fixtures/zookeeper/txn/setdatatxn.go
@@ -10,14 +10,14 @@ import (
 )
 
 type SetDataTxn struct {
-	Path    *string // path
-	Data    []byte  // data
-	Version int32   // version
+	Path    string // path
+	Data    []byte // data
+	Version int32  // version
 }
 
 func (r *SetDataTxn) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }

--- a/testdata/fixtures/zookeeper/txn/setmaxchildrentxn.go
+++ b/testdata/fixtures/zookeeper/txn/setmaxchildrentxn.go
@@ -10,13 +10,13 @@ import (
 )
 
 type SetMaxChildrenTxn struct {
-	Path *string // path
-	Max  int32   // max
+	Path string // path
+	Max  int32  // max
 }
 
 func (r *SetMaxChildrenTxn) GetPath() string {
-	if r != nil && r.Path != nil {
-		return *r.Path
+	if r != nil {
+		return r.Path
 	}
 	return ""
 }


### PR DESCRIPTION
According to the [jute docs](https://zookeeper.apache.org/doc/r3.4.11/api/org/apache/jute/package-summary.html), the `ustring` type ends up being a `std::string` in C++, which is not nillable.

This PR makes it consistent with C++, and uses the Go native type instead of a reference.

When encoding it, write a "-1" if it is an empty string, same as the [Python library is doing](https://github.com/python-zk/kazoo/blob/6b6ffe62a073d1ed5413c65c2d8ec94ea2fa1760/kazoo/protocol/serialization.py#L47).